### PR TITLE
rectification error

### DIFF
--- a/libshims/sensor.cpp
+++ b/libshims/sensor.cpp
@@ -54,7 +54,7 @@ static void dummy(void) {
 	manager.configureDirectChannel(0, 0, 0);
 	Vector<float> floats;
 	Vector<int32_t>	ints;
-	manager.setOperationParameter(0, 0, floats, ints);
+	manager.setOperationParameter(0, floats, ints);
 
 	sp<ISensorEventConnection> connection;
 	SensorEventQueue* queue	= new SensorEventQueue(connection);


### PR DESCRIPTION
error : too many arguments to function call, expected 3, have 4
        manager.setOperationParameter(0, 0, floats, ints);
Fixed